### PR TITLE
Support for ActiveResource (incl. tests)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@
 .rvmrc
 .bundle
 Gemfile.lock
+spec/orm_adapter/adapters/active_resource_server/server.log
 
 # built docs
 .yardoc

--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,7 @@
 source "http://rubygems.org"
 
 gemspec
+
+# For testing ActiveResource integration uncomment these:
+# gem 'rails', '~> 3.0'
+# gem 'sqlite3'

--- a/Gemfile
+++ b/Gemfile
@@ -3,5 +3,6 @@ source "http://rubygems.org"
 gemspec
 
 # For testing ActiveResource integration uncomment these:
-# gem 'rails', '~> 3.0'
-# gem 'sqlite3'
+gem 'rails', '~> 3.0'
+gem 'sqlite3'
+

--- a/lib/orm_adapter.rb
+++ b/lib/orm_adapter.rb
@@ -15,6 +15,7 @@ module OrmAdapter
 end
 
 require 'orm_adapter/adapters/active_record' if defined?(ActiveRecord::Base)
+require 'orm_adapter/adapters/active_resource' if defined?(ActiveResource::Base)
 require 'orm_adapter/adapters/data_mapper'   if defined?(DataMapper::Resource)
 require 'orm_adapter/adapters/mongoid'       if defined?(Mongoid::Document)
 require 'orm_adapter/adapters/mongo_mapper'  if defined?(MongoMapper::Document)

--- a/lib/orm_adapter/adapters/active_resource.rb
+++ b/lib/orm_adapter/adapters/active_resource.rb
@@ -1,0 +1,79 @@
+begin
+  require 'activeresource'
+rescue LoadError
+  require 'active_resource'
+end
+
+class ActiveResource::Base
+  extend OrmAdapter::ToAdapter
+  
+  class OrmAdapter < ::OrmAdapter::Base
+    # Do not consider these to be part of the class list
+    def self.except_classes
+      @@except_classes ||= []
+    end
+
+    # Gets a list of the available models for this adapter
+    def self.model_classes
+      begin
+        klasses = ::ActiveResource::Base.__send__(:descendants) # Rails 3
+      rescue
+        klasses = ::ActiveResource::Base.__send__(:subclasses) # Rails 2
+      end
+
+      klasses.select do |klass|
+        !except_classes.include?(klass.name)
+      end
+    end
+
+    # Return list of column/property names
+    def column_names
+      klass.column_names
+    end
+
+    # @see OrmAdapter::Base#get!
+    def get!(id)
+      klass.find(wrap_key(id))
+    end
+
+    # @see OrmAdapter::Base#get
+    def get(id)
+      klass.find(:first, :params => {:id => wrap_key(id)})
+    end
+
+    # @see OrmAdapter::Base#find_first
+    def find_first(options)
+      conditions, order = extract_conditions_and_order!(options)
+      klass.find(:first, :params => conditions_to_fields(conditions).merge(order_clause(order)))
+    end
+
+    # @see OrmAdapter::Base#find_all
+    def find_all(options)
+      conditions, order = extract_conditions_and_order!(options)
+      klass.find(:all, :params => conditions_to_fields(conditions).merge(order_clause(order)))
+    end
+    
+    # @see OrmAdapter::Base#create!
+    def create!(attributes)
+      klass.create(attributes)
+    end
+    
+  protected
+    # Introspects the klass to convert and objects in conditions into foreign key and type fields
+    def conditions_to_fields(conditions)
+      fields = {}
+      conditions.each do |key, value|
+        if !klass.schema[key] && klass.schema[key.to_s + "_id"]
+          fields[key.to_s + "_id"] = value
+        else
+          fields[key] = value
+        end
+      end
+      fields
+    end
+    
+    def order_clause(order)
+      {:order => order.map {|pair| "#{pair[0]} #{pair[1]}"}.join(",")}
+    end
+  end
+end

--- a/lib/orm_adapter/adapters/active_resource.rb
+++ b/lib/orm_adapter/adapters/active_resource.rb
@@ -63,7 +63,7 @@ class ActiveResource::Base
     def conditions_to_fields(conditions)
       fields = {}
       conditions.each do |key, value|
-        if !klass.schema[key] && klass.schema[key.to_s + "_id"]
+        if klass.schema && !klass.schema[key] && klass.schema[key.to_s + "_id"]
           fields[key.to_s + "_id"] = value
         else
           fields[key] = value

--- a/spec/orm_adapter/adapters/active_resource_server/config.ru
+++ b/spec/orm_adapter/adapters/active_resource_server/config.ru
@@ -1,0 +1,4 @@
+# This file is used by Rack-based servers to start the application.
+
+require ::File.expand_path('../server',  __FILE__)
+run ActiveResourceServer::Application

--- a/spec/orm_adapter/adapters/active_resource_server/controllers.rb
+++ b/spec/orm_adapter/adapters/active_resource_server/controllers.rb
@@ -1,0 +1,57 @@
+class Hash
+  def only(*whitelist)
+    {}.tap do |h|
+      (keys & whitelist).each { |k| h[k] = self[k] }
+    end
+  end
+end
+
+class UsersController < ActionController::Base
+  respond_to :xml
+
+  def index
+    respond_with(@users = User.where(params.only('name', 'rating')).order(params[:order]))
+  end
+  
+  def create
+    params[:user].delete('__content__')
+    params[:user][:notes].map! {|n| Note.find(n[:id]) } rescue nil
+    @user = User.create(params[:user])
+    respond_with(@user)
+  end
+  
+  def show
+    respond_with(@user = User.find(params[:id]))
+  end
+  
+  def destroy
+    @user = User.find(params[:id])
+    @user.destroy
+    head :ok
+  end
+end
+
+class NotesController < ActionController::Base
+  respond_to :xml
+  
+  def index
+    respond_with(@notes = Note.where(params.only('owner_id')).order(params[:order]))
+  end
+  
+  def show
+    respond_with Note.find(params[:id])
+  end
+  
+  def create
+    params[:note].delete('__content__')
+    params[:note][:owner] = User.find_by_id(params[:note][:owner_id] || params[:note][:owner][:id]) rescue nil
+    @note = Note.create(params[:note])
+    respond_with(@note)
+  end
+  
+  def destroy
+    @note = Note.find(params[:id])
+    @note.destroy
+    head :ok
+  end
+end

--- a/spec/orm_adapter/adapters/active_resource_server/models.rb
+++ b/spec/orm_adapter/adapters/active_resource_server/models.rb
@@ -1,0 +1,7 @@
+class User < ActiveRecord::Base
+  has_many :notes, :foreign_key => 'owner_id'
+end
+
+class Note < ActiveRecord::Base
+  belongs_to :owner, :class_name => "User"
+end

--- a/spec/orm_adapter/adapters/active_resource_server/server.rb
+++ b/spec/orm_adapter/adapters/active_resource_server/server.rb
@@ -1,0 +1,41 @@
+require 'rubygems'
+ENV['RAILS_ENV'] = 'test'
+ENV['BUNDLE_GEMFILE'] ||= File.expand_path('../../../../../../Gemfile', __FILE__)
+require 'bundler/setup' if File.exists?(ENV['BUNDLE_GEMFILE'])
+require 'rails/all'
+Bundler.require(:default, Rails.env) if defined?(Bundler)
+
+class Rails::Application::Configuration
+ def database_configuration
+   {'test' => {'adapter' => 'sqlite3', 'database' => '/tmp/orm_adapter_test.sqlite'}}
+ end
+end
+
+ActiveSupport.on_load(:before_initialize) do
+  ActiveRecord::Migration.suppress_messages do
+    ActiveRecord::Schema.define(:version => 0) do
+      create_table(:users, :force => true) {|t| t.string :name; t.integer :rating; }
+      create_table(:notes, :force => true) {|t| t.belongs_to :owner, :polymorphic => true }
+    end
+  end
+end
+
+module ActiveResourceServer
+  class Application < Rails::Application
+    config.active_support.deprecation = :log
+    config.secret_token = ActiveSupport::SecureRandom.hex(30)
+    config.logger = Logger.new ::Rails.root.to_s + "/server.log"
+
+    initializer 'routes' do |app|
+      app.routes.draw do
+        resources :users
+        resources :notes
+      end
+    end
+  end
+end
+
+require File.expand_path('../models', __FILE__)
+require File.expand_path('../controllers', __FILE__)
+
+ActiveResourceServer::Application.initialize!

--- a/spec/orm_adapter/adapters/active_resource_spec.rb
+++ b/spec/orm_adapter/adapters/active_resource_spec.rb
@@ -1,0 +1,65 @@
+require 'spec_helper'
+require 'orm_adapter/example_app_shared'
+
+if !defined?(ActiveResource::Base)
+  puts "** require 'active_resource' to run the specs in #{__FILE__}"
+else
+  module ActiveResourceOrmSpec
+    class User < ActiveResource::Base
+      self.site = "http://localhost:31777/"
+      schema do
+        string 'name'
+        integer 'rating'
+      end
+      def notes; Note.find(:all, :params => {:owner_id => id}) || []; end
+    end
+
+    class Note < ActiveResource::Base
+      self.site = "http://localhost:31777/"
+      schema do
+        integer 'owner_id'
+      end
+      def owner; User.find(owner_id); end
+    end
+  
+    # here be the specs!
+    describe ActiveResource::Base::OrmAdapter do
+      before(:all) do
+        @server_pid = fork do
+          server_dir = File.expand_path(__FILE__ + '/../active_resource_server')
+          FileUtils.rm(server_dir + '/server.log') rescue nil
+          $stdout.reopen('/dev/null', 'w')
+          $stderr.reopen('/dev/null', 'w')
+          exec('bundle exec rackup -p 31777 ' + server_dir + '/config.ru')
+        end
+        sleep 5
+      end
+      after(:all) do
+        Process.kill "KILL", @server_pid 
+        Process.waitpid @server_pid
+      end
+
+      before do
+        User.find(:all).each {|u| u.destroy }
+        Note.find(:all).each {|n| n.destroy }
+      end
+
+      describe "the OrmAdapter class" do
+        subject { ActiveResource::Base::OrmAdapter }
+
+        specify "#model_classes should return all model classes" do
+          subject.model_classes.should include(User, Note)
+        end
+      end
+
+      it_should_behave_like "example app with orm_adapter" do
+        let(:user_class) { User }
+        let(:note_class) { Note }
+
+        def create_model(klass, attrs = {})
+          klass.create(attrs)
+        end
+      end
+    end
+  end
+end

--- a/spec/orm_adapter/example_app_shared.rb
+++ b/spec/orm_adapter/example_app_shared.rb
@@ -93,8 +93,10 @@ shared_examples_for "example app with orm_adapter" do
       
         it "when conditions contain associated object, should return first model if it exists" do
           user = create_model(user_class)
-          note = create_model(note_class, :owner => user)
-          note_adapter.find_first(:owner => user).should == note
+          user2 = create_model(user_class)
+          note = create_model(note_class, :owner => user2)
+          note2 = create_model(note_class, :owner => user)
+          note_adapter.find_first(:owner => user).should == note2
         end
       end
     

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -3,7 +3,7 @@ require 'rspec'
 
 $:.unshift(File.dirname(__FILE__) + '/../lib')
 
-['dm-core', 'mongoid', 'active_record', 'mongo_mapper'].each do |orm|
+['dm-core', 'mongoid', 'active_record', 'active_resource', 'mongo_mapper'].each do |orm|
   begin
     require orm
   rescue LoadError


### PR DESCRIPTION
Hi Ian,

When using devise I noticed that ActiveResource wasn't supported - we have a frontend Rails app that uses ActiveResource to access an internal backend API.

I've now added support for ActiveResource to orm_adapter, as this seems like the correct place.

I've also added tests, including a super-tiny Rails code base (shortened into 3 files) that serves as the ActiveResource backend server.

The tests are only enabled when you uncomment the rails and sqlite3 gem in the Gemfile (see comment there).

Let me know what you think & would be very happy to see these changes upstream.

Cheers,
Lukas
