### PR TITLE
Only monkey patch ActiveRecord::Base when it's been loaded.

### DIFF
--- a/lib/orm_adapter/adapters/active_record.rb
+++ b/lib/orm_adapter/adapters/active_record.rb
@@ -6,7 +6,7 @@ end
 
 module OrmAdapter
   class ActiveRecord < Base
-      # Do not consider these to be part of the class list
+    # Do not consider these to be part of the class list
     def self.except_classes
       @@except_classes ||= [
         "CGI::Session::ActiveRecordStore::Session",

--- a/lib/orm_adapter/adapters/active_record.rb
+++ b/lib/orm_adapter/adapters/active_record.rb
@@ -4,91 +4,91 @@ rescue LoadError
   require 'active_record'
 end
 
-ActiveSupport.on_load(:active_record) do
-  class ActiveRecord::Base
-    extend OrmAdapter::ToAdapter
-
-    class OrmAdapter < ::OrmAdapter::Base
-
+module OrmAdapter
+  class ActiveRecord < Base
       # Do not consider these to be part of the class list
-      def self.except_classes
-        @@except_classes ||= [
-          "CGI::Session::ActiveRecordStore::Session",
-          "ActiveRecord::SessionStore::Session"
-        ]
+    def self.except_classes
+      @@except_classes ||= [
+        "CGI::Session::ActiveRecordStore::Session",
+        "ActiveRecord::SessionStore::Session"
+      ]
+    end
+
+    # Gets a list of the available models for this adapter
+    def self.model_classes
+      begin
+        klasses = ::ActiveRecord::Base.__send__(:descendants) # Rails 3
+      rescue
+        klasses = ::ActiveRecord::Base.__send__(:subclasses) # Rails 2
       end
 
-      # Gets a list of the available models for this adapter
-      def self.model_classes
-        begin
-          klasses = ::ActiveRecord::Base.__send__(:descendants) # Rails 3
-        rescue
-          klasses = ::ActiveRecord::Base.__send__(:subclasses) # Rails 2
-        end
-
-        klasses.select do |klass|
-          !klass.abstract_class? && !except_classes.include?(klass.name)
-        end
-      end
-
-      # Return list of column/property names
-      def column_names
-        klass.column_names
-      end
-
-      # @see OrmAdapter::Base#get!
-      def get!(id)
-        klass.find(wrap_key(id))
-      end
-
-      # @see OrmAdapter::Base#get
-      def get(id)
-        klass.first :conditions => { klass.primary_key => wrap_key(id) }
-      end
-
-      # @see OrmAdapter::Base#find_first
-      def find_first(options)
-        conditions, order = extract_conditions_and_order!(options)
-        klass.first :conditions => conditions_to_fields(conditions), :order => order_clause(order)
-      end
-
-      # @see OrmAdapter::Base#find_all
-      def find_all(options)
-        conditions, order = extract_conditions_and_order!(options)
-        klass.all :conditions => conditions_to_fields(conditions), :order => order_clause(order)
-      end
-
-      # @see OrmAdapter::Base#create!
-      def create!(attributes)
-        klass.create!(attributes)
-      end
-
-    protected
-
-      # Introspects the klass to convert and objects in conditions into foreign key and type fields
-      def conditions_to_fields(conditions)
-        fields = {}
-        conditions.each do |key, value|
-          if value.is_a?(ActiveRecord::Base) && (assoc = klass.reflect_on_association(key.to_sym)) && assoc.belongs_to?
-
-            if ActiveRecord::VERSION::STRING < "3.1"
-              fields[assoc.primary_key_name] = value.send(value.class.primary_key)
-              fields[assoc.options[:foreign_type]] = value.class.base_class.name.to_s if assoc.options[:polymorphic]
-            else # >= 3.1
-              fields[assoc.foreign_key] = value.send(value.class.primary_key)
-              fields[assoc.foreign_type] = value.class.base_class.name.to_s if assoc.options[:polymorphic]
-            end
-
-          else
-            fields[key] = value
-          end
-        end
-        fields
-      end
-
-      def order_clause(order)
-        order.map {|pair| "#{pair[0]} #{pair[1]}"}.join(",")
+      klasses.select do |klass|
+        !klass.abstract_class? && !except_classes.include?(klass.name)
       end
     end
+
+    # Return list of column/property names
+    def column_names
+      klass.column_names
+    end
+
+    # @see OrmAdapter::Base#get!
+    def get!(id)
+      klass.find(wrap_key(id))
+    end
+
+    # @see OrmAdapter::Base#get
+    def get(id)
+      klass.first :conditions => { klass.primary_key => wrap_key(id) }
+    end
+
+    # @see OrmAdapter::Base#find_first
+    def find_first(options)
+      conditions, order = extract_conditions_and_order!(options)
+      klass.first :conditions => conditions_to_fields(conditions), :order => order_clause(order)
+    end
+
+    # @see OrmAdapter::Base#find_all
+    def find_all(options)
+      conditions, order = extract_conditions_and_order!(options)
+      klass.all :conditions => conditions_to_fields(conditions), :order => order_clause(order)
+    end
+
+    # @see OrmAdapter::Base#create!
+    def create!(attributes)
+      klass.create!(attributes)
+    end
+
+  protected
+
+    # Introspects the klass to convert and objects in conditions into foreign key and type fields
+    def conditions_to_fields(conditions)
+      fields = {}
+      conditions.each do |key, value|
+        if value.is_a?(::ActiveRecord::Base) && (assoc = klass.reflect_on_association(key.to_sym)) && assoc.belongs_to?
+
+          if ::ActiveRecord::VERSION::STRING < "3.1"
+            fields[assoc.primary_key_name] = value.send(value.class.primary_key)
+            fields[assoc.options[:foreign_type]] = value.class.base_class.name.to_s if assoc.options[:polymorphic]
+          else # >= 3.1
+            fields[assoc.foreign_key] = value.send(value.class.primary_key)
+            fields[assoc.foreign_type] = value.class.base_class.name.to_s if assoc.options[:polymorphic]
+          end
+
+        else
+          fields[key] = value
+        end
+      end
+      fields
+    end
+
+    def order_clause(order)
+      order.map {|pair| "#{pair[0]} #{pair[1]}"}.join(",")
+    end
   end
+end
+
+ActiveSupport.on_load(:active_record) do
+  extend ::OrmAdapter::ToAdapter
+  self::OrmAdapter = ::OrmAdapter::ActiveRecord
 end

--- a/lib/orm_adapter/adapters/active_record.rb
+++ b/lib/orm_adapter/adapters/active_record.rb
@@ -4,89 +4,91 @@ rescue LoadError
   require 'active_record'
 end
 
-class ActiveRecord::Base
-  extend OrmAdapter::ToAdapter
-  
-  class OrmAdapter < ::OrmAdapter::Base
+ActiveSupport.on_load(:active_record) do
+  class ActiveRecord::Base
+    extend OrmAdapter::ToAdapter
 
-    # Do not consider these to be part of the class list
-    def self.except_classes
-      @@except_classes ||= [
-        "CGI::Session::ActiveRecordStore::Session",
-        "ActiveRecord::SessionStore::Session"
-      ]
-    end
+    class OrmAdapter < ::OrmAdapter::Base
 
-    # Gets a list of the available models for this adapter
-    def self.model_classes
-      begin
-        klasses = ::ActiveRecord::Base.__send__(:descendants) # Rails 3
-      rescue
-        klasses = ::ActiveRecord::Base.__send__(:subclasses) # Rails 2
+      # Do not consider these to be part of the class list
+      def self.except_classes
+        @@except_classes ||= [
+          "CGI::Session::ActiveRecordStore::Session",
+          "ActiveRecord::SessionStore::Session"
+        ]
       end
 
-      klasses.select do |klass|
-        !klass.abstract_class? && !except_classes.include?(klass.name)
-      end
-    end
+      # Gets a list of the available models for this adapter
+      def self.model_classes
+        begin
+          klasses = ::ActiveRecord::Base.__send__(:descendants) # Rails 3
+        rescue
+          klasses = ::ActiveRecord::Base.__send__(:subclasses) # Rails 2
+        end
 
-    # Return list of column/property names
-    def column_names
-      klass.column_names
-    end
-
-    # @see OrmAdapter::Base#get!
-    def get!(id)
-      klass.find(wrap_key(id))
-    end
-
-    # @see OrmAdapter::Base#get
-    def get(id)
-      klass.first :conditions => { klass.primary_key => wrap_key(id) }
-    end
-
-    # @see OrmAdapter::Base#find_first
-    def find_first(options)
-      conditions, order = extract_conditions_and_order!(options)
-      klass.first :conditions => conditions_to_fields(conditions), :order => order_clause(order)
-    end
-
-    # @see OrmAdapter::Base#find_all
-    def find_all(options)
-      conditions, order = extract_conditions_and_order!(options)
-      klass.all :conditions => conditions_to_fields(conditions), :order => order_clause(order)
-    end
-    
-    # @see OrmAdapter::Base#create!
-    def create!(attributes)
-      klass.create!(attributes)
-    end
-    
-  protected
-
-    # Introspects the klass to convert and objects in conditions into foreign key and type fields
-    def conditions_to_fields(conditions)
-      fields = {}
-      conditions.each do |key, value|
-        if value.is_a?(ActiveRecord::Base) && (assoc = klass.reflect_on_association(key.to_sym)) && assoc.belongs_to?
-          
-          if ActiveRecord::VERSION::STRING < "3.1"
-            fields[assoc.primary_key_name] = value.send(value.class.primary_key)          
-            fields[assoc.options[:foreign_type]] = value.class.base_class.name.to_s if assoc.options[:polymorphic]
-          else # >= 3.1
-            fields[assoc.foreign_key] = value.send(value.class.primary_key)          
-            fields[assoc.foreign_type] = value.class.base_class.name.to_s if assoc.options[:polymorphic]
-          end
-          
-        else
-          fields[key] = value
+        klasses.select do |klass|
+          !klass.abstract_class? && !except_classes.include?(klass.name)
         end
       end
-      fields
-    end
-    
-    def order_clause(order)
-      order.map {|pair| "#{pair[0]} #{pair[1]}"}.join(",")
+
+      # Return list of column/property names
+      def column_names
+        klass.column_names
+      end
+
+      # @see OrmAdapter::Base#get!
+      def get!(id)
+        klass.find(wrap_key(id))
+      end
+
+      # @see OrmAdapter::Base#get
+      def get(id)
+        klass.first :conditions => { klass.primary_key => wrap_key(id) }
+      end
+
+      # @see OrmAdapter::Base#find_first
+      def find_first(options)
+        conditions, order = extract_conditions_and_order!(options)
+        klass.first :conditions => conditions_to_fields(conditions), :order => order_clause(order)
+      end
+
+      # @see OrmAdapter::Base#find_all
+      def find_all(options)
+        conditions, order = extract_conditions_and_order!(options)
+        klass.all :conditions => conditions_to_fields(conditions), :order => order_clause(order)
+      end
+
+      # @see OrmAdapter::Base#create!
+      def create!(attributes)
+        klass.create!(attributes)
+      end
+
+    protected
+
+      # Introspects the klass to convert and objects in conditions into foreign key and type fields
+      def conditions_to_fields(conditions)
+        fields = {}
+        conditions.each do |key, value|
+          if value.is_a?(ActiveRecord::Base) && (assoc = klass.reflect_on_association(key.to_sym)) && assoc.belongs_to?
+
+            if ActiveRecord::VERSION::STRING < "3.1"
+              fields[assoc.primary_key_name] = value.send(value.class.primary_key)
+              fields[assoc.options[:foreign_type]] = value.class.base_class.name.to_s if assoc.options[:polymorphic]
+            else # >= 3.1
+              fields[assoc.foreign_key] = value.send(value.class.primary_key)
+              fields[assoc.foreign_type] = value.class.base_class.name.to_s if assoc.options[:polymorphic]
+            end
+
+          else
+            fields[key] = value
+          end
+        end
+        fields
+      end
+
+      def order_clause(order)
+        order.map {|pair| "#{pair[0]} #{pair[1]}"}.join(",")
+      end
     end
   end
 end


### PR DESCRIPTION
This prevents the database connection being activated when it is not appropriate.
E.g. asset precompilation with sprockets.

All relevant tests passing for me.
@josevalim Also all of devise tests are passing with this change.

Also, all tests pass with Refinery CMS with this change which is the reason I'm making this change so that asset pre-compilation works out of the box with Heroku.

Thanks! :)
