### PR TITLE
Add Sequel plugin

### DIFF
--- a/lib/orm_adapter.rb
+++ b/lib/orm_adapter.rb
@@ -16,5 +16,6 @@ end
 
 require 'orm_adapter/adapters/active_record' if defined?(ActiveRecord::Base)
 require 'orm_adapter/adapters/data_mapper'   if defined?(DataMapper::Resource)
+require 'orm_adapter/adapters/sequel'        if defined?(Sequel::Model)
 require 'orm_adapter/adapters/mongoid'       if defined?(Mongoid::Document)
 require 'orm_adapter/adapters/mongo_mapper'  if defined?(MongoMapper::Document)

--- a/lib/orm_adapter/adapters/sequel.rb
+++ b/lib/orm_adapter/adapters/sequel.rb
@@ -1,0 +1,89 @@
+require 'sequel'
+
+module Sequel
+  module Plugins
+    module OrmAdapter 
+      # The OrmAdapter plugin requires the subclasses plugin to get a list
+      # of subclasses, the active_model plugin for ActiveModel compliance,
+      # and the instance_hooks plugin to support association= for one_to_many
+      # associations.
+      def self.apply(model)
+        model.plugin :subclasses
+        model.plugin :active_model
+        model.plugin :instance_hooks
+      end
+
+      module ClassMethods
+        include ::OrmAdapter::ToAdapter
+
+        # Add an association= method for one_to_many associations that
+        # associates each object in the given array to the object after
+        # saving.
+        def def_one_to_many(opts)
+          s = super
+          unless opts[:type] == :one_to_one
+            association_module_def(opts.setter_method) do |objs|
+              after_save_hook{objs.each{|obj| send(opts.add_method, obj)}}
+            end
+          end
+          s
+        end
+      end
+    end
+  end
+
+  class Model
+    plugin Plugins::OrmAdapter
+  
+    class OrmAdapter < ::OrmAdapter::Base
+
+      # Do not consider these to be part of the class list
+      def self.except_classes
+        @@except_classes ||= []
+      end
+
+      # Gets a list of the available models for this adapter
+      def self.model_classes
+        ::Sequel::Model.descendents.select{|k| !except_classes.include?(k.name)}
+      end
+
+      # get a list of column names for a given class
+      def column_names
+        klass.columns
+      end
+
+      # @see OrmAdapter::Base#get!
+      def get!(id)
+        klass[id] || raise(::Sequel::Error, "no record with primary key #{id.inspect} found")
+      end
+
+      # @see OrmAdapter::Base#get
+      def get(id)
+        klass[id]
+      end
+
+      # @see OrmAdapter::Base#find_first
+      def find_first(options)
+        conditions, order = extract_conditions_and_order!(options)
+        klass.filter(conditions).order(*order_clause(order)).first
+      end
+
+      # @see OrmAdapter::Base#find_all
+      def find_all(options)
+        conditions, order = extract_conditions_and_order!(options)
+        klass.filter(conditions).order(*order_clause(order)).all
+      end
+    
+      # @see OrmAdapter::Base#create!
+      def create!(attributes)
+        klass.create(attributes)
+      end
+      
+    protected
+      
+      def order_clause(order)
+        order.map {|pair| Sequel.send(pair.last, pair.first)}
+      end
+    end
+  end
+end

--- a/spec/orm_adapter/adapters/sequel_spec.rb
+++ b/spec/orm_adapter/adapters/sequel_spec.rb
@@ -1,0 +1,59 @@
+require 'spec_helper'
+require 'orm_adapter/example_app_shared'
+
+if !defined?(Sequel)
+  puts "** require 'sequel' to run the specs in #{__FILE__}"
+else  
+  
+  module SequelOrmSpec
+    DB = Sequel.sqlite
+    DB.create_table(:users) do
+      primary_key :id
+      String :name
+      Integer :rating
+    end
+    DB.create_table(:notes) do
+      primary_key :id
+      String :body
+      Integer :owner_id
+    end
+
+    class User < Sequel::Model
+    end
+
+    class Note < Sequel::Model
+    end
+
+    User.one_to_many :notes, :class=>Note, :key=>:owner_id
+    Note.many_to_one :owner, :class=>User
+    
+    # here be the specs!
+    describe Sequel::Model::OrmAdapter do
+      before do
+        User.destroy
+        Note.destroy
+      end
+      
+      describe "the OrmAdapter class" do
+        subject { Sequel::Model::OrmAdapter }
+
+        specify "#model_classes should return all of the non abstract model classes (that are not in except_classes)" do
+          subject.model_classes.should == [User, Note]
+        end
+      end
+
+      it_should_behave_like "example app with orm_adapter" do
+        def create_model(klass, attrs = {})
+          klass.create(attrs)
+        end
+  
+        let(:user_class) { User }
+        let(:note_class) { Note }
+        
+        def reload_model(model)
+          model.reload
+        end
+      end
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -3,7 +3,7 @@ require 'rspec'
 
 $:.unshift(File.dirname(__FILE__) + '/../lib')
 
-['dm-core', 'mongoid', 'active_record', 'mongo_mapper'].each do |orm|
+['dm-core', 'mongoid', 'active_record', 'mongo_mapper', 'sequel'].each do |orm|
   begin
     require orm
   rescue LoadError


### PR DESCRIPTION
This plugin is based on the data_mapper plugin, modified to use
the Sequel API.  Sequel natively supports most features of
orm_adapter, only the association= method needs to be emulated.
