### PR TITLE
added collection adapter for active record

### DIFF
--- a/lib/orm_adapter/adapters/active_record.rb
+++ b/lib/orm_adapter/adapters/active_record.rb
@@ -107,5 +107,4 @@ end
 ActiveSupport.on_load(:active_record) do
   extend ::OrmAdapter::ToAdapter
   self::OrmAdapter = ::OrmAdapter::ActiveRecord
-  ActiveRecord::Associations::CollectionAssociation.send :include, ::OrmAdapter::ToCollectionAdapter
 end

--- a/lib/orm_adapter/adapters/active_record.rb
+++ b/lib/orm_adapter/adapters/active_record.rb
@@ -66,41 +66,41 @@ module OrmAdapter
       order.map {|pair| "#{pair[0]} #{pair[1]}"}.join(",")
     end
 
-    class Collection
-
-      attr_reader :collection
-
-      def initialize(collection)
-        @collection = collection
-      end
-
-      def klass
-        collection.klass
-      end
-
-      def klass_adapter
-        @klass_adapter ||= klass.to_adapter
-      end
-
-      def find_first(options = {})
-        conditions, order = klass_adapter.send(:extract_conditions!, options)
-        collection.scoped.where(klass_adapter.send(:conditions_to_fields, conditions)).order(*klass_adapter.send(:order_clause, order)).first
-      end
-
-      def find(options = {})
-        conditions, order, limit, offset = klass_adapter.send(:extract_conditions!, options)
-        collection.scoped.where(klass_adapter.send(:conditions_to_fields, conditions)).order(*klass_adapter.send(:order_clause, order)).limit(limit).offset(offset)
-      end
-
-      def build(attributes = {})
-        collection.build(attributes)
-      end
-
-      def create!(attributes = {})
-        collection.create!(attributes)
-      end
-
-    end
+    #class Collection
+    #
+    #  attr_reader :collection
+    #
+    #  def initialize(collection)
+    #    @collection = collection
+    #  end
+    #
+    #  def klass
+    #    collection.klass
+    #  end
+    #
+    #  def klass_adapter
+    #    @klass_adapter ||= klass.to_adapter
+    #  end
+    #
+    #  def find_first(options = {})
+    #    conditions, order = klass_adapter.send(:extract_conditions!, options)
+    #    collection.scoped.where(klass_adapter.send(:conditions_to_fields, conditions)).order(*klass_adapter.send(:order_clause, order)).first
+    #  end
+    #
+    #  def find(options = {})
+    #    conditions, order, limit, offset = klass_adapter.send(:extract_conditions!, options)
+    #    collection.scoped.where(klass_adapter.send(:conditions_to_fields, conditions)).order(*klass_adapter.send(:order_clause, order)).limit(limit).offset(offset)
+    #  end
+    #
+    #  def build(attributes = {})
+    #    collection.build(attributes)
+    #  end
+    #
+    #  def create!(attributes = {})
+    #    collection.create!(attributes)
+    #  end
+    #
+    #end
   end
 end
 
@@ -108,6 +108,4 @@ ActiveSupport.on_load(:active_record) do
   extend ::OrmAdapter::ToAdapter
   self::OrmAdapter = ::OrmAdapter::ActiveRecord
   ActiveRecord::Associations::CollectionAssociation.send :include, ::OrmAdapter::ToCollectionAdapter
-  ActiveRecord::Associations::CollectionAssociation::OrmAdapter = ::OrmAdapter::ActiveRecord::Collection
-  ActiveRecord::Associations::CollectionProxy.delegate :to_adapter, :to => :@association
 end

--- a/lib/orm_adapter/adapters/active_record.rb
+++ b/lib/orm_adapter/adapters/active_record.rb
@@ -9,29 +9,33 @@ module OrmAdapter
 
     # @see OrmAdapter::Base#get!
     def get!(id)
-      klass.find(wrap_key(id))
+      scoped.find(wrap_key(id))
     end
 
     # @see OrmAdapter::Base#get
     def get(id)
-      klass.where(klass.primary_key => wrap_key(id)).first
+      scoped.where(klass.primary_key => wrap_key(id)).first
     end
 
     # @see OrmAdapter::Base#find_first
     def find_first(options = {})
       conditions, order = extract_conditions!(options)
-      klass.where(conditions_to_fields(conditions)).order(*order_clause(order)).first
+      scoped.where(conditions_to_fields(conditions)).order(*order_clause(order)).first
     end
 
     # @see OrmAdapter::Base#find_all
     def find_all(options = {})
       conditions, order, limit, offset = extract_conditions!(options)
-      klass.where(conditions_to_fields(conditions)).order(*order_clause(order)).limit(limit).offset(offset).all
+      scoped.where(conditions_to_fields(conditions)).order(*order_clause(order)).limit(limit).offset(offset).all
+    end
+
+    def build(attributes = {})
+      scoped.build(attributes)
     end
 
     # @see OrmAdapter::Base#create!
     def create!(attributes = {})
-      klass.create!(attributes)
+      scoped.create!(attributes)
     end
 
     # @see OrmAdapter::Base#destroy
@@ -40,6 +44,10 @@ module OrmAdapter
     end
 
   protected
+
+    def scoped
+      klass.where(conditions_to_fields(@scope))
+    end
 
     # Introspects the klass to convert and objects in conditions into foreign key and type fields
     def conditions_to_fields(conditions)

--- a/lib/orm_adapter/adapters/mongo_mapper.rb
+++ b/lib/orm_adapter/adapters/mongo_mapper.rb
@@ -14,19 +14,19 @@ module MongoMapper
 
       # @see OrmAdapter::Base#get!
       def get!(id)
-        klass.find!(wrap_key(id))
+        scoped.find!(wrap_key(id))
       end
 
       # @see OrmAdapter::Base#get
       def get(id)
-        klass.first({ :id => wrap_key(id) })
+        scoped.first({ :id => wrap_key(id) })
       end
 
       # @see OrmAdapter::Base#find_first
       def find_first(conditions = {})
         conditions, order = extract_conditions!(conditions)
         conditions = conditions.merge(:sort => order) unless order.nil?
-        klass.first(conditions_to_fields(conditions))
+        scoped.first(conditions_to_fields(conditions))
       end
 
       # @see OrmAdapter::Base#find_all
@@ -35,12 +35,17 @@ module MongoMapper
         conditions = conditions.merge(:sort => order) unless order.nil?
         conditions = conditions.merge(:limit => limit) unless limit.nil?
         conditions = conditions.merge(:offset => offset) unless limit.nil? || offset.nil?
-        klass.all(conditions_to_fields(conditions))
+        scoped.all(conditions_to_fields(conditions))
+      end
+
+      # @see OrmAdapter::Base#build
+      def build(attributes = {})
+        klass.new(@scope.merge(attributes))
       end
 
       # @see OrmAdapter::Base#create!
       def create!(attributes = {})
-        klass.create!(attributes)
+        klass.create!(@scope.merge(attributes))
       end
 
       # @see OrmAdapter::Base#destroy
@@ -49,6 +54,10 @@ module MongoMapper
       end
 
     protected
+
+      def scoped
+        klass.where(conditions_to_fields(@scope))
+      end
 
       # converts and documents to ids
       def conditions_to_fields(conditions)

--- a/lib/orm_adapter/adapters/mongoid.rb
+++ b/lib/orm_adapter/adapters/mongoid.rb
@@ -14,29 +14,34 @@ module Mongoid
 
       # @see OrmAdapter::Base#get!
       def get!(id)
-        klass.find(wrap_key(id))
+        scoped.find(wrap_key(id))
       end
 
       # @see OrmAdapter::Base#get
       def get(id)
-        klass.where(:_id => wrap_key(id)).first
+        scoped.where(:_id => wrap_key(id)).first
       end
 
       # @see OrmAdapter::Base#find_first
       def find_first(options = {})
         conditions, order = extract_conditions!(options)
-        klass.limit(1).where(conditions_to_fields(conditions)).order_by(order).first
+        scoped.limit(1).where(conditions_to_fields(conditions)).order_by(order).first
       end
 
       # @see OrmAdapter::Base#find_all
       def find_all(options = {})
         conditions, order, limit, offset = extract_conditions!(options)
-        klass.where(conditions_to_fields(conditions)).order_by(order).limit(limit).offset(offset)
+        scoped.where(conditions_to_fields(conditions)).order_by(order).limit(limit).offset(offset)
+      end
+
+      # @see OrmAdapter::Base#build
+      def build(attributes = {})
+        scoped.new(attributes)
       end
 
       # @see OrmAdapter::Base#create!
       def create!(attributes = {})
-        klass.create!(attributes)
+        scoped.create!(attributes)
       end
 
       # @see OrmAdapter::Base#destroy
@@ -45,6 +50,10 @@ module Mongoid
       end
 
     protected
+
+      def scoped
+        klass.where(conditions_to_fields(@scope))
+      end
 
       # converts and documents to ids
       def conditions_to_fields(conditions)

--- a/lib/orm_adapter/base.rb
+++ b/lib/orm_adapter/base.rb
@@ -1,6 +1,6 @@
 module OrmAdapter
   class Base
-    attr_reader :klass
+    attr_reader :klass, :scope
 
     # Your ORM adapter needs to inherit from this Base class and its adapter
     # will be registered. To create an adapter you should create an inner
@@ -14,8 +14,9 @@ module OrmAdapter
       super
     end
 
-    def initialize(klass)
+    def initialize(klass, scope={})
       @klass = klass
+      @scope = scope
     end
 
     # Get a list of column/property/field names
@@ -68,6 +69,10 @@ module OrmAdapter
       raise NotSupportedError
     end
 
+    def build(attributes = {})
+      raise NotSupportedError
+    end
+
     # Create a model using attributes
     def create!(attributes = {})
       raise NotSupportedError
@@ -116,21 +121,6 @@ module OrmAdapter
       end
 
       order
-    end
-  end
-
-
-  module Collection
-    class Base
-      attr_reader :collection
-
-      def initialize(collection)
-        @collection = collection
-      end
-
-      def klass
-        raise NotSupportedError
-      end
     end
   end
 

--- a/lib/orm_adapter/base.rb
+++ b/lib/orm_adapter/base.rb
@@ -119,6 +119,21 @@ module OrmAdapter
     end
   end
 
+
+  module Collection
+    class Base
+      attr_reader :collection
+
+      def initialize(collection)
+        @collection = collection
+      end
+
+      def klass
+        raise NotSupportedError
+      end
+    end
+  end
+
   class NotSupportedError < NotImplementedError
     def to_s
       "method not supported by this orm adapter"

--- a/lib/orm_adapter/to_adapter.rb
+++ b/lib/orm_adapter/to_adapter.rb
@@ -5,4 +5,10 @@ module OrmAdapter
       @_to_adapter ||= self::OrmAdapter.new(self)
     end
   end
+
+  module ToCollectionAdapter
+    def to_adapter
+      @_to_adapter ||= self.class::OrmAdapter.new(self)
+    end
+  end
 end

--- a/lib/orm_adapter/to_adapter.rb
+++ b/lib/orm_adapter/to_adapter.rb
@@ -1,8 +1,8 @@
 module OrmAdapter
   # Extend into a class that has an OrmAdapter
   module ToAdapter
-    def to_adapter
-      @_to_adapter ||= self::OrmAdapter.new(self)
+    def to_adapter(scope = {})
+      self::OrmAdapter.new(self, scope)
     end
   end
 

--- a/lib/orm_adapter/to_adapter.rb
+++ b/lib/orm_adapter/to_adapter.rb
@@ -6,9 +6,4 @@ module OrmAdapter
     end
   end
 
-  module ToCollectionAdapter
-    def to_adapter
-      @_to_adapter ||= self.class::OrmAdapter.new(self)
-    end
-  end
 end

--- a/spec/orm_adapter/adapters/active_record_spec.rb
+++ b/spec/orm_adapter/adapters/active_record_spec.rb
@@ -9,7 +9,7 @@ else
   ActiveRecord::Migration.suppress_messages do
     ActiveRecord::Schema.define(:version => 0) do
       create_table(:users, :force => true) {|t| t.string :name; t.integer :rating; }
-      create_table(:notes, :force => true) {|t| t.belongs_to :owner, :polymorphic => true }
+      create_table(:notes, :force => true) {|t| t.belongs_to :owner, :polymorphic => true ; t.string :description }
     end
   end
   

--- a/spec/orm_adapter/adapters/active_record_spec.rb
+++ b/spec/orm_adapter/adapters/active_record_spec.rb
@@ -9,7 +9,7 @@ else
   ActiveRecord::Migration.suppress_messages do
     ActiveRecord::Schema.define(:version => 0) do
       create_table(:users, :force => true) {|t| t.string :name; t.integer :rating; }
-      create_table(:notes, :force => true) {|t| t.belongs_to :owner, :polymorphic => true ; t.string :description }
+      create_table(:notes, :force => true) {|t| t.belongs_to :owner, :polymorphic => true }
     end
   end
   

--- a/spec/orm_adapter/adapters/mongo_mapper_spec.rb
+++ b/spec/orm_adapter/adapters/mongo_mapper_spec.rb
@@ -27,9 +27,7 @@ else
     describe MongoMapper::Document::OrmAdapter do
       
       before do
-        MongoMapper.database.collections.each do | coll |
-          coll.remove
-        end
+        MongoMapper.database.collections.each(&:remove)
       end
     
       it_should_behave_like "example app with orm_adapter" do

--- a/spec/orm_adapter/adapters/mongoid_spec.rb
+++ b/spec/orm_adapter/adapters/mongoid_spec.rb
@@ -6,7 +6,7 @@ if !defined?(Mongoid) || !(Mongo::Connection.new.db('orm_adapter_spec') rescue n
 else  
   
   Mongoid.configure do |config|
-    config.master = Mongo::Connection.new.db('orm_adapter_spec')
+    config.connect_to( 'orm_adapter_spec' )
   end
   
   module MongoidOrmSpec
@@ -14,13 +14,13 @@ else
       include Mongoid::Document
       field :name
       field :rating
-      has_many_related :notes, :foreign_key => :owner_id, :class_name => 'MongoidOrmSpec::Note'
+      has_many :notes, :foreign_key => :owner_id, :class_name => 'MongoidOrmSpec::Note'
     end
 
     class Note
       include Mongoid::Document
       field :body, :default => "made by orm"
-      belongs_to_related :owner, :class_name => 'MongoidOrmSpec::User'
+      belongs_to :owner, :class_name => 'MongoidOrmSpec::User'
     end
     
     # here be the specs!

--- a/spec/orm_adapter/example_app_shared.rb
+++ b/spec/orm_adapter/example_app_shared.rb
@@ -39,7 +39,7 @@ shared_examples_for "example app with orm_adapter" do
       subject.to_adapter.klass.should == subject
     end
 
-    it "#to_adapter should be cached" do
+    pending "#to_adapter should be cached" do
       subject.to_adapter.object_id.should == subject.to_adapter.object_id
     end
   end
@@ -47,6 +47,7 @@ shared_examples_for "example app with orm_adapter" do
   describe "adapter instance" do
     let(:note_adapter) { note_class.to_adapter }
     let(:user_adapter) { user_class.to_adapter }
+    let(:scoped_user_adapter) { user_class.to_adapter(:name => "balls") }
 
     describe "#get!(id)" do
       it "should return the instance with id if it exists" do
@@ -63,16 +64,13 @@ shared_examples_for "example app with orm_adapter" do
         lambda { user_adapter.get!("nonexistent id") }.should raise_error
       end
 
-      describe "scoped" do
-        let(:user_adapter) { user_class.to_adapter(:name => "balls") }
-        it "should return the instance if it belongs to the scope" do
-          user = create_model(user_class, :name => "balls")
-          user_adapter.get!(user.id).should == user
-        end
-        it "should not return the instance if it does not belong to the scope" do
-          user = create_model(user_class)
-          user_adapter.get!(user.id).should raise_error
-        end
+      it "should return the instance if it belongs to the scope" do
+        user = create_model(user_class, :name => "balls")
+        scoped_user_adapter.get!(user.id).should == user
+      end
+      it "should not return the instance if it does not belong to the scope" do
+        user = create_model(user_class)
+        lambda { scoped_user_adapter.get!(user.id) }.should raise_error
       end
     end
 
@@ -91,16 +89,13 @@ shared_examples_for "example app with orm_adapter" do
         user_adapter.get("nonexistent id").should be_nil
       end
 
-      describe "scoped" do
-        let(:user_adapter) { user_class.to_adapter(:name => "balls") }
-        it "should return the instance if it belongs to the scope" do
-          user = create_model(user_class, :name => "balls")
-          user_adapter.get!(user.id).should == user
-        end
-        it "should not return the instance if it does not belong to the scope" do
-          user = create_model(user_class)
-          user_adapter.get!(user.id).should == nil
-        end
+      it "should return the instance if it belongs to the scope" do
+        user = create_model(user_class, :name => "balls")
+        scoped_user_adapter.get(user.id).should == user
+      end
+      it "should not return the instance if it does not belong to the scope" do
+        user = create_model(user_class)
+        scoped_user_adapter.get(user.id).should == nil
       end
     end
 
@@ -152,11 +147,10 @@ shared_examples_for "example app with orm_adapter" do
       end
 
       describe "scoped" do
-        let(:user_adapter) { user_class.to_adapter(:name => "balls") }
         it "should return first model matching conditions belonging to the scope" do
           user1 = create_model(user_class, :name => "something else")
           user2 = create_model(user_class, :name => "balls")
-          user_adapter.find_first.should == user2
+          scoped_user_adapter.find_first.should == user2
         end
       end
     end
@@ -229,13 +223,12 @@ shared_examples_for "example app with orm_adapter" do
       end
 
       describe "scoped" do
-        let(:user_adapter) { user_class.to_adapter(:name => "balls") }
         it "should return all models matching conditions belonging to the scope" do
           user1 = create_model(user_class, :name => "something else")
           user2 = create_model(user_class, :name => "something other")
           user3 = create_model(user_class, :name => "balls")
           user4 = create_model(user_class, :name => "balls")
-          user_adapter.find_all.should == [user3, user4]
+          scoped_user_adapter.find_all.should == [user3, user4]
         end
       end
     end
@@ -264,9 +257,8 @@ shared_examples_for "example app with orm_adapter" do
       end
 
       describe "scoped" do
-        let(:user_adapter) { user_class.to_adapter(:name => "balls") }
         it "should pass the adapter conditions as attributes to the built model" do
-          user = user_adapter.build
+          user = scoped_user_adapter.build
           user.name.should == "balls"
         end
       end
@@ -295,9 +287,8 @@ shared_examples_for "example app with orm_adapter" do
       end
 
       describe "scoped" do
-        let(:user_adapter) { user_class.to_adapter(:name => "balls") }
         it "should pass the adapter conditions as attributes to the created model" do
-          user = user_adapter.create!
+          user = scoped_user_adapter.create!
           reload_model(user).name.should == "balls"
         end
       end

--- a/spec/orm_adapter/example_app_shared.rb
+++ b/spec/orm_adapter/example_app_shared.rb
@@ -237,4 +237,57 @@ shared_examples_for "example app with orm_adapter" do
       end
     end
   end
+
+  describe "an ORM collection" do
+    def notes_adapter
+      user.notes.to_adapter
+    end
+    let(:user) { create_model(user_class) }
+    describe "#klass" do
+      it "should return the class of the elements belonging to the collection" do
+        user.notes.to_adapter.klass.should == note_class
+      end
+    end
+    describe "#find_first" do
+      describe "(conditions)" do
+        describe "if note belongs to the user" do
+          it "should return first model matching conditions, if it exists" do
+            create_model(note_class, :description => "stuff")
+            note = create_model(note_class, :owner => user, :description => "stuff")
+            notes_adapter.find_first(:description => "stuff").should == note
+          end
+        end
+
+        describe "if note does not belongs to the user" do
+          it "should not return first model matching conditions, if it exists" do
+            create_model(note_class, :description => "stuff")
+            notes_adapter.find_first(:description => "stuff").should == nil
+          end
+        end
+      end
+    end
+
+    describe "#find" do
+      it "should only return notes belonging to the given user" do
+        note1 = create_model(note_class, :owner => user)
+        note2 = create_model(note_class, :owner => user)
+        note3 = create_model(note_class)
+        note4 = create_model(note_class)
+        notes_adapter.find.should == [note1, note2]
+      end
+    end
+
+    describe "#create!" do
+      it "should create the object with the association to the collection owner established" do
+        note = notes_adapter.create!
+        note.owner.should == user
+      end
+    end
+    describe "#build" do
+      it "should build the object and establish the association to the collection owner" do
+        note = notes_adapter.build
+        note.owner = user
+      end
+    end
+  end
 end

--- a/spec/orm_adapter/example_app_shared.rb
+++ b/spec/orm_adapter/example_app_shared.rb
@@ -297,7 +297,7 @@ shared_examples_for "example app with orm_adapter" do
     describe "#destroy(instance)" do
       it "should destroy the instance if it exists" do
         user = create_model(user_class)
-        user_adapter.destroy(user).should == true
+        user_adapter.destroy(user).should be_true
         user_adapter.get(user.id).should be_nil
       end
 

--- a/spec/orm_adapter/example_app_shared.rb
+++ b/spec/orm_adapter/example_app_shared.rb
@@ -238,56 +238,59 @@ shared_examples_for "example app with orm_adapter" do
     end
   end
 
-  describe "an ORM collection" do
-    def notes_adapter
-      user.notes.to_adapter
-    end
-    let(:user) { create_model(user_class) }
-    describe "#klass" do
-      it "should return the class of the elements belonging to the collection" do
-        user.notes.to_adapter.klass.should == note_class
-      end
-    end
-    describe "#find_first" do
-      describe "(conditions)" do
-        describe "if note belongs to the user" do
-          it "should return first model matching conditions, if it exists" do
-            create_model(note_class, :description => "stuff")
-            note = create_model(note_class, :owner => user, :description => "stuff")
-            notes_adapter.find_first(:description => "stuff").should == note
-          end
-        end
-
-        describe "if note does not belongs to the user" do
-          it "should not return first model matching conditions, if it exists" do
-            create_model(note_class, :description => "stuff")
-            notes_adapter.find_first(:description => "stuff").should == nil
-          end
-        end
-      end
-    end
-
-    describe "#find" do
-      it "should only return notes belonging to the given user" do
-        note1 = create_model(note_class, :owner => user)
-        note2 = create_model(note_class, :owner => user)
-        note3 = create_model(note_class)
-        note4 = create_model(note_class)
-        notes_adapter.find.should == [note1, note2]
-      end
-    end
-
-    describe "#create!" do
-      it "should create the object with the association to the collection owner established" do
-        note = notes_adapter.create!
-        note.owner.should == user
-      end
-    end
-    describe "#build" do
-      it "should build the object and establish the association to the collection owner" do
-        note = notes_adapter.build
-        note.owner = user
-      end
     end
   end
+
+  #describe "an ORM collection" do
+  #  def notes_adapter
+  #    user.notes.to_adapter
+  #  end
+  #  let(:user) { create_model(user_class) }
+  #  describe "#klass" do
+  #    it "should return the class of the elements belonging to the collection" do
+  #      user.notes.to_adapter.klass.should == note_class
+  #    end
+  #  end
+  #  describe "#find_first" do
+  #    describe "(conditions)" do
+  #      describe "if note belongs to the user" do
+  #        it "should return first model matching conditions, if it exists" do
+  #          create_model(note_class, :description => "stuff")
+  #          note = create_model(note_class, :owner => user, :description => "stuff")
+  #          notes_adapter.find_first(:description => "stuff").should == note
+  #        end
+  #      end
+  #
+  #      describe "if note does not belongs to the user" do
+  #        it "should not return first model matching conditions, if it exists" do
+  #          create_model(note_class, :description => "stuff")
+  #          notes_adapter.find_first(:description => "stuff").should == nil
+  #        end
+  #      end
+  #    end
+  #  end
+  #
+  #  describe "#find" do
+  #    it "should only return notes belonging to the given user" do
+  #      note1 = create_model(note_class, :owner => user)
+  #      note2 = create_model(note_class, :owner => user)
+  #      note3 = create_model(note_class)
+  #      note4 = create_model(note_class)
+  #      notes_adapter.find.should == [note1, note2]
+  #    end
+  #  end
+  #
+  #  describe "#create!" do
+  #    it "should create the object with the association to the collection owner established" do
+  #      note = notes_adapter.create!
+  #      note.owner.should == user
+  #    end
+  #  end
+  #  describe "#build" do
+  #    it "should build the object and establish the association to the collection owner" do
+  #      note = notes_adapter.build
+  #      note.owner = user
+  #    end
+  #  end
+  #end
 end


### PR DESCRIPTION
Referring to https://github.com/ianwhite/orm_adapter/issues/27

This is just a discussion starting point. As you may have seen, I add the collection adapter only to ActiveRecord. This is because I wanted to discuss with you the gem extension, the validity of the additional API, and if we agree on it, some corrections to the specs/internal implementation I added, and other possible extensions to the general purpose API, before writing adapters to other ORMs.

So, this is my point of view: I think that the collections not only represent an abstraction present in all ORM implementations, they also offer some general CRUD scoped methods that can be useful to the further extension of certain gems. From that perspective it would be interesting to bring them all together. 

So, please don't close the request before we discuss this further. I think it would be more interesting to add this to the existing gem instead of adding a new "collection_orm_adapter" gem. 
