### PR TITLE
Add #simple_key that is needed for Mongoid

### DIFF
--- a/lib/orm_adapter/adapters/active_record.rb
+++ b/lib/orm_adapter/adapters/active_record.rb
@@ -2,6 +2,11 @@ require 'active_record'
 
 module OrmAdapter
   class ActiveRecord < Base
+    # @see OrmAdapter::Base#simple_key
+    def simple_key
+      object.id
+    end
+
     # Return list of column/property names
     def column_names
       klass.column_names
@@ -37,7 +42,7 @@ module OrmAdapter
       object.destroy && true if valid_object?(object)
     end
 
-  protected
+    protected
     def construct_relation(relation, options)
       conditions, order, limit, offset = extract_conditions!(options)
 

--- a/lib/orm_adapter/adapters/data_mapper.rb
+++ b/lib/orm_adapter/adapters/data_mapper.rb
@@ -7,6 +7,11 @@ module DataMapper
 
   module Resource
     class OrmAdapter < ::OrmAdapter::Base
+      # @see OrmAdapter::Base#simple_key
+      def simple_key
+        object.id
+      end
+
       # get a list of column names for a given class
       def column_names
         klass.properties.map(&:name)

--- a/lib/orm_adapter/adapters/mongo_mapper.rb
+++ b/lib/orm_adapter/adapters/mongo_mapper.rb
@@ -7,6 +7,11 @@ module MongoMapper
     end
 
     class OrmAdapter < ::OrmAdapter::Base
+      # @see OrmAdapter::Base#simple_key
+      def simple_key
+        object.id.to_s
+      end
+
       # get a list of column names for a given class
       def column_names
         klass.column_names

--- a/lib/orm_adapter/adapters/mongoid.rb
+++ b/lib/orm_adapter/adapters/mongoid.rb
@@ -7,6 +7,11 @@ module Mongoid
     end
 
     class OrmAdapter < ::OrmAdapter::Base
+      # @see OrmAdapter::Base#simple_key
+      def simple_key
+        object.id.to_s
+      end
+
       # get a list of column names for a given class
       def column_names
         klass.fields.keys

--- a/lib/orm_adapter/base.rb
+++ b/lib/orm_adapter/base.rb
@@ -18,6 +18,11 @@ module OrmAdapter
       @klass = klass
     end
 
+    # Return field key that is ready for serialization (needed for Mongoid)
+    def simple_key
+      raise NotSupportedError
+    end
+
     # Get a list of column/property/field names
     def column_names
       raise NotSupportedError


### PR DESCRIPTION
Mongoid #to_key returns `BSON::ObjectId` which is serialized to `{"$oid": "blahblah"}`. This method will now return string which will not cause errors like plataformatec/devise#2882.
