### PR TITLE
RSpec changes needed for Neo4j Orm Adapter

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,7 +2,7 @@ source "https://rubygems.org"
 
 gemspec
 
-gem "rspec", "~> 2.0"
+gem "rspec", "~> 2.4"
 gem "sqlite3", ">= 1.3.2", :platforms => :ruby
 gem "bson_ext", ">= 1.3.2", :platforms => :ruby
 gem 'activerecord-jdbcsqlite3-adapter', :platforms => :jruby

--- a/Gemfile
+++ b/Gemfile
@@ -2,6 +2,7 @@ source "https://rubygems.org"
 
 gemspec
 
+gem "rspec", "~> 2.0"
 gem "sqlite3", ">= 1.3.2", :platforms => :ruby
 gem "bson_ext", ">= 1.3.2", :platforms => :ruby
 gem 'activerecord-jdbcsqlite3-adapter', :platforms => :jruby

--- a/gemfiles/activerecord-4.0.gemfile
+++ b/gemfiles/activerecord-4.0.gemfile
@@ -2,7 +2,7 @@ source "https://rubygems.org"
 
 gem "rake", ">= 10"
 gem "activerecord", "~> 4.0.4"
-gem "rspec", ">= 2.4.0"
+gem "rspec", "~> 2.4"
 
 gem "sqlite3", ">= 1.3.2", :platforms => :ruby
 gem "bson_ext", ">= 1.3.2", :platforms => :ruby

--- a/gemfiles/activerecord-4.1.gemfile
+++ b/gemfiles/activerecord-4.1.gemfile
@@ -2,7 +2,7 @@ source "https://rubygems.org"
 
 gem "rake", ">= 10"
 gem "activerecord", "~> 4.1.0"
-gem "rspec", ">= 2.4.0"
+gem "rspec", "~> 2.4"
 
 gem "sqlite3", ">= 1.3.2", :platforms => :ruby
 gem "bson_ext", ">= 1.3.2", :platforms => :ruby

--- a/spec/orm_adapter/example_app_shared.rb
+++ b/spec/orm_adapter/example_app_shared.rb
@@ -1,3 +1,5 @@
+# Copied from orm_adapter and fixed some Specs
+
 # to test your new orm_adapter, make an example app that matches the functionality
 # found in the existing specs for example, look at spec/orm_adapter/adapters/active_record_spec.rb
 #
@@ -179,8 +181,8 @@ shared_examples_for "example app with orm_adapter" do
           user1 = create_model(user_class, :name => "Fred", :rating => 1)
           user2 = create_model(user_class, :name => "Fred", :rating => 2)
           user3 = create_model(user_class, :name => "Betty", :rating => 3)
-          user_adapter.find_all(:limit => 1, :order => [:rating, :asc]).to_a.should == [user1]
-          user_adapter.find_all(:limit => 2, :order => [:rating, :asc]).to_a.should == [user1, user2]
+          user_adapter.find_all(:limit => 1, :order => [:rating, :asc]).should == [user1]
+          user_adapter.find_all(:limit => 2, :order => [:rating, :asc]).should == [user1, user2]
         end
       end
 
@@ -188,10 +190,10 @@ shared_examples_for "example app with orm_adapter" do
         it "should return an offset set of matching models" do
           user1 = create_model(user_class, :name => "Fred", :rating => 1)
           user2 = create_model(user_class, :name => "Fred", :rating => 2)
-          user3 = create_model(user_class, :name => "Betty", :rating => 1)
-          user_adapter.find_all(:limit => 3, :offset => 0).to_a.should =~ [user1, user2, user3]
-          user_adapter.find_all(:limit => 3, :offset => 1).to_a.should =~ [user2, user3]
-          user_adapter.find_all(:limit => 1, :offset => 1).to_a.should == [user2]
+          user3 = create_model(user_class, :name => "Betty", :rating => 3)
+          user_adapter.find_all(:limit => 3, :offset => 0, :order => [:rating, :asc]).should == [user1, user2, user3]
+          user_adapter.find_all(:limit => 3, :offset => 1, :order => [:rating, :asc]).should == [user2, user3]
+          user_adapter.find_all(:limit => 1, :offset => 1, :order => [:rating, :asc]).should == [user2]
         end
       end
     end

--- a/spec/orm_adapter/example_app_shared.rb
+++ b/spec/orm_adapter/example_app_shared.rb
@@ -134,14 +134,14 @@ shared_examples_for "example app with orm_adapter" do
           user1 = create_model(user_class, :name => "Fred")
           user2 = create_model(user_class, :name => "Fred")
           user3 = create_model(user_class, :name => "Betty")
-          user_adapter.find_all(:name => "Fred").should == [user1, user2]
+          user_adapter.find_all(:name => "Fred").to_a.should =~ [user1, user2]
         end
 
         it "should return all models if no conditions passed" do
           user1 = create_model(user_class, :name => "Fred")
           user2 = create_model(user_class, :name => "Fred")
           user3 = create_model(user_class, :name => "Betty")
-          user_adapter.find_all.should == [user1, user2, user3]
+          user_adapter.find_all.to_a.should =~ [user1, user2, user3]
         end
 
         it "should return empty array if no conditions match" do
@@ -178,9 +178,9 @@ shared_examples_for "example app with orm_adapter" do
         it "should return a limited set of matching models" do
           user1 = create_model(user_class, :name => "Fred", :rating => 1)
           user2 = create_model(user_class, :name => "Fred", :rating => 2)
-          user3 = create_model(user_class, :name => "Betty", :rating => 1)
-          user_adapter.find_all(:limit => 1).should == [user1]
-          user_adapter.find_all(:limit => 2).should == [user1, user2]
+          user3 = create_model(user_class, :name => "Betty", :rating => 3)
+          user_adapter.find_all(:limit => 1, :order => [:rating, :asc]).to_a.should == [user1]
+          user_adapter.find_all(:limit => 2, :order => [:rating, :asc]).to_a.should == [user1, user2]
         end
       end
 
@@ -189,9 +189,9 @@ shared_examples_for "example app with orm_adapter" do
           user1 = create_model(user_class, :name => "Fred", :rating => 1)
           user2 = create_model(user_class, :name => "Fred", :rating => 2)
           user3 = create_model(user_class, :name => "Betty", :rating => 1)
-          user_adapter.find_all(:limit => 3, :offset => 0).should == [user1, user2, user3]
-          user_adapter.find_all(:limit => 3, :offset => 1).should == [user2, user3]
-          user_adapter.find_all(:limit => 1, :offset => 1).should == [user2]
+          user_adapter.find_all(:limit => 3, :offset => 0).to_a.should =~ [user1, user2, user3]
+          user_adapter.find_all(:limit => 3, :offset => 1).to_a.should =~ [user2, user3]
+          user_adapter.find_all(:limit => 1, :offset => 1).to_a.should == [user2]
         end
       end
     end
@@ -222,7 +222,7 @@ shared_examples_for "example app with orm_adapter" do
     describe "#destroy(instance)" do
       it "should destroy the instance if it exists" do
         user = create_model(user_class)
-        user_adapter.destroy(user).should be_true
+        (!!user_adapter.destroy(user)).should == true  # make it work with both RSpec 2.x and 3.x
         user_adapter.get(user.id).should be_nil
       end
 


### PR DESCRIPTION
Some RSpec changes (bug fixes) in order to make the neo4j orm_adapter happy.
- Using :offset and :limit does not make sense without using :order in `find_all`
- RSpec 3.0 was released. Fixed one spec so it works both for RSpec 2.x and 3.x
