### PR TITLE
Skip sql sorting while fetching a record by id

### DIFF
--- a/lib/orm_adapter/adapters/active_record.rb
+++ b/lib/orm_adapter/adapters/active_record.rb
@@ -14,7 +14,7 @@ module OrmAdapter
 
     # @see OrmAdapter::Base#get
     def get(id)
-      klass.where(klass.primary_key => wrap_key(id)).first
+      klass.send("find_by_#{klass.primary_key}", wrap_key(id))
     end
 
     # @see OrmAdapter::Base#find_first


### PR DESCRIPTION
Skip sql sorting while fetching a record by id, by replacing where().first with #find_by_*

It will be one idea faster because there will be no sorting.
