### PR TITLE
Link to rubygems to find the available adapters

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -28,7 +28,7 @@ Provides a single point of entry for popular ruby ORMs.  Its target audience is 
 
 Currently supported ORMs are *ActiveRecord*, *DataMapper*, *MongoMapper*, and *MongoId*.
 
-We welcome you to write new adapters as gems. ORM Adapter will stay focused in having these major ORMs working. Other adapters will be named `orm_adapter-somedatabase`, you can find the ones available {on rubygems a filter}[https://rubygems.org/search?query=orm_adapter-].
+We welcome you to write new adapters as gems. ORM Adapter will stay focused in having these major ORMs working. Other adapters will be named <tt>orm_adapter-somedatabase</tt>, you can find the ones available {on rubygems a filter}[https://rubygems.org/search?query=orm_adapter-].
 
 To write an adapter look at <tt>lib/orm_adapter/adapters/active_record.rb</tt> for an example of implementation.  To see how to test it, look at <tt>spec/orm_adapter/example_app_shared.rb</tt>, <tt>spec/orm_adapter/adapters/active_record_spec.rb</tt>.  You'll need to require the target ORM in <tt>spec/spec_helper.rb</tt>
 

--- a/README.rdoc
+++ b/README.rdoc
@@ -28,7 +28,7 @@ Provides a single point of entry for popular ruby ORMs.  Its target audience is 
 
 Currently supported ORMs are *ActiveRecord*, *DataMapper*, *MongoMapper*, and *MongoId*.
 
-We welcome you to write new adapters as gems. ORM Adapter will stay focused in having these major ORMs working.
+We welcome you to write new adapters as gems. ORM Adapter will stay focused in having these major ORMs working. Other adapters will be named `orm_adapter-somedatabase`, you can find the ones available {on rubygems a filter}[https://rubygems.org/search?query=orm_adapter-].
 
 To write an adapter look at <tt>lib/orm_adapter/adapters/active_record.rb</tt> for an example of implementation.  To see how to test it, look at <tt>spec/orm_adapter/example_app_shared.rb</tt>, <tt>spec/orm_adapter/adapters/active_record_spec.rb</tt>.  You'll need to require the target ORM in <tt>spec/spec_helper.rb</tt>
 


### PR DESCRIPTION
As @ianwhite mentioned in https://github.com/ianwhite/orm_adapter/issues/25 it would be nice to have a link to the available adapters on rubygems.
