### PR TITLE
Remove deprecated option from gemspec

### DIFF
--- a/orm_adapter.gemspec
+++ b/orm_adapter.gemspec
@@ -12,7 +12,6 @@ Gem::Specification.new do |s|
   s.homepage = "http://github.com/ianwhite/orm_adapter"
   s.license = "MIT"
 
-  s.rubyforge_project = "orm_adapter"
   s.required_rubygems_version = ">= 1.3.6"
 
   s.files         = `git ls-files`.split("\n")


### PR DESCRIPTION
This is deprecated by rubygems:

NOTE: Gem::Specification#rubyforge_project= is deprecated with no replacement. It will be removed on or after 2019-12-01.